### PR TITLE
Implement functionality to create anchored time-index

### DIFF
--- a/s2s/time.py
+++ b/s2s/time.py
@@ -7,35 +7,160 @@ Time indices are anchored to the target period of interest. By keeping keeping
 observations from the same cycle (typically 1 year) together and paying close
 attention to the treatment of adjacent cycles, we avoid information leakage
 between train and test sets.
+
+Example:
+
+    >>> import s2s.time
+    >>>
+    >>> # Countdown the weeks until New Year's Eve
+    >>> calendar = s2s.time.AdventCalendar(anchor_date=(12, 31), freq="7d")
+    >>> calendar
+    AdventCalendar(month=12, day=31, freq=7d, n=52)
+    >>> print(calendar)
+    "52 periods of 7d leading up to 12/31."
+
+    >>> # Get the 60-day periods leading up to New Year's eve for the year 2020
+    >>> calendar = s2s.time.AdventCalendar(anchor_date=(12, 31), freq='60d')
+    >>> calendar.map_year(2020)
+    t-0    (2020-11-01, 2020-12-31]
+    t-1    (2020-09-02, 2020-11-01]
+    t-2    (2020-07-04, 2020-09-02]
+    t-3    (2020-05-05, 2020-07-04]
+    t-4    (2020-03-06, 2020-05-05]
+    t-5    (2020-01-06, 2020-03-06]
+    Name: 2020, dtype: interval
+
+    >>> # Get the 180-day periods leading up to New Year's eve for 2020 - 2022 inclusive.
+    >>> calendar = s2s.time.AdventCalendar(anchor_date=(12, 31), freq='180d')
+    >>> # note the leap year:
+    >>> calendar.map_years(2020, 2022)
+                                t-0                       t-1
+    2022  (2022-07-04, 2022-12-31]  (2022-01-05, 2022-07-04]
+    2021  (2021-07-04, 2021-12-31]  (2021-01-05, 2021-07-04]
+    2020  (2020-07-04, 2020-12-31]  (2020-01-06, 2020-07-04]
+
+    >>> # To get a stacked representation:
+    >>> calendar.map_years(2020, 2022, flat=True)
+    0    (2022-07-04, 2022-12-31]
+    1    (2022-01-05, 2022-07-04]
+    2    (2021-07-04, 2021-12-31]
+    3    (2021-01-05, 2021-07-04]
+    4    (2020-07-04, 2020-12-31]
+    5    (2020-01-06, 2020-07-04]
+    dtype: interval
+
 """
 import pandas as pd
+from typing import Tuple
 
 
 class AdventCalendar:
     """Countdown time to anticipated anchor date or period of interest."""
 
-    def __init__(self, anchor_date=(11, 30), freq="7d"):
+    def __init__(
+        self, anchor_date: Tuple[int, int] = (11, 30), freq: str = "7d"
+    ) -> None:
         """Instantiate a basic calendar with minimal configuration.
 
-        Set up the calendar with given freq ending exactly on the anchor date. The
-        index will extend back in time as many periods as fit within the cycle
-        time.
+        Set up the calendar with given freq ending exactly on the anchor date.
+        The index will extend back in time as many periods as fit within the
+        cycle time of one year.
+
+        Args:
+            anchor_date: Tuple of the form (month, day). Effectively the origin
+                of the calendar. It will countdown until this date. freq:
+                Frequency of the calendar.
+
+        Example:
+            Instantiate a calendar counting down the weeks until new-year's
+            eve.
+
+            >>> import s2s.time
+            >>> calendar = s2s.time.AdventCalendar(anchor_date=(12, 31), freq="7d")
+            >>> calendar
+            AdventCalendar(month=12, day=31, freq=7d, n=52)
+            >>> print(calendar)
+            "52 periods of 7d leading up to 12/31."
+
         """
         self.month = anchor_date[0]
         self.day = anchor_date[1]
         self.freq = freq
         self.n = pd.Timedelta("365days") // pd.to_timedelta(freq)
 
-    def map_year(self, year):
-        """Return a concrete IntervalIndex for the given year."""
+    def map_year(self, year: int) -> pd.Series:
+        """Return a concrete IntervalIndex for the given year.
+
+        Since the AdventCalendar represents a periodic event, it is first
+        instantiated without a specific year. This method adds a specific year
+        to the calendar and returns an intervalindex, applying the
+        AdvenctCalendar to this specific year.
+
+        Args:
+            year: The year for which the AdventCalendar will be realized
+
+        Returns:
+            intervals: pandas series filled with Intervals of the calendar's
+                frequency, counting backwards from the calendar's anchor_date.
+
+        Example:
+
+            >>> import s2s.time
+            >>> calendar = s2s.time.AdventCalendar(anchor_date=(12, 31), freq='60d')
+            >>> calendar.map_year(2020)
+            t-0    (2020-11-01, 2020-12-31]
+            t-1    (2020-09-02, 2020-11-01]
+            t-2    (2020-07-04, 2020-09-02]
+            t-3    (2020-05-05, 2020-07-04]
+            t-4    (2020-03-06, 2020-05-05]
+            t-5    (2020-01-06, 2020-03-06]
+            Name: 2020, dtype: interval
+        """
         anchor = pd.Timestamp(year, self.month, self.day)
         intervals = pd.interval_range(end=anchor, periods=self.n, freq=self.freq)
         intervals = pd.Series(intervals[::-1], name=str(year))
         intervals.index = intervals.index.map(lambda i: f"t-{i}")
         return intervals
 
-    def map_years(self, start=1979, end=2020, flat=False):
-        """Return a periodic IntervalIndex for the given years."""
+    def map_years(
+        self, start: int = 1979, end: int = 2020, flat: bool = False
+    ) -> pd.DataFrame:
+        """Return a periodic IntervalIndex for the given years.
+
+        Like ``map_year``, but for multiple years.
+
+        Args:
+            start: The first year for which the calendar will be realized
+            end: The last year for which the calendar will be realized
+            flat: If False, years are rows and lag times are columns in the
+                dataframe. If True, years and lags are stacked to form a
+                continous index.
+
+        Returns:
+            intervals: pandas dataframe filled with Intervals of the calendar's
+                frequency, counting backwards from the calendar's anchor_date.
+
+        Example:
+
+            >>> import s2s.time
+            >>> calendar = s2s.time.AdventCalendar(anchor_date=(12, 31), freq='180d')
+            >>> # note the leap year:
+            >>> calendar.map_years(2020, 2022)
+                                       t-0                       t-1
+            2022  (2022-07-04, 2022-12-31]  (2022-01-05, 2022-07-04]
+            2021  (2021-07-04, 2021-12-31]  (2021-01-05, 2021-07-04]
+            2020  (2020-07-04, 2020-12-31]  (2020-01-06, 2020-07-04]
+
+            >>> # To get a stacked representation:
+            >>> calendar.map_years(2020, 2022, flat=True)
+            0    (2022-07-04, 2022-12-31]
+            1    (2022-01-05, 2022-07-04]
+            2    (2021-07-04, 2021-12-31]
+            3    (2021-01-05, 2021-07-04]
+            4    (2020-07-04, 2020-12-31]
+            5    (2020-01-06, 2020-07-04]
+            dtype: interval
+        """
         index = pd.concat(
             [self.map_year(year) for year in range(start, end + 1)], axis=1
         ).T[::-1]

--- a/s2s/time.py
+++ b/s2s/time.py
@@ -50,8 +50,8 @@ Example:
     dtype: interval
 
 """
-import pandas as pd
 from typing import Tuple
+import pandas as pd
 
 
 class AdventCalendar:

--- a/s2s/time.py
+++ b/s2s/time.py
@@ -100,8 +100,8 @@ class AdventCalendar:
             year: The year for which the AdventCalendar will be realized
 
         Returns:
-            intervals: pandas series filled with Intervals of the calendar's
-                frequency, counting backwards from the calendar's anchor_date.
+            Pandas Series filled with Intervals of the calendar's frequency, counting
+            backwards from the calendar's anchor_date.
 
         Example:
 
@@ -137,8 +137,8 @@ class AdventCalendar:
                 continous index.
 
         Returns:
-            intervals: pandas dataframe filled with Intervals of the calendar's
-                frequency, counting backwards from the calendar's anchor_date.
+            Pandas DataFrame filled with Intervals of the calendar's frequency,
+            counting backwards from the calendar's anchor_date.
 
         Example:
 

--- a/s2s/time.py
+++ b/s2s/time.py
@@ -17,7 +17,7 @@ Example:
     >>> calendar
     AdventCalendar(month=12, day=31, freq=7d, n=52)
     >>> print(calendar)
-    "52 periods of 7d leading up to 12/31."
+    52 periods of 7d leading up to 12/31.
 
     >>> # Get the 60-day periods leading up to New Year's eve for the year 2020
     >>> calendar = s2s.time.AdventCalendar(anchor_date=(12, 31), freq='60d')
@@ -34,7 +34,7 @@ Example:
     >>> calendar = s2s.time.AdventCalendar(anchor_date=(12, 31), freq='180d')
     >>> # note the leap year:
     >>> calendar.map_years(2020, 2022)
-                                t-0                       t-1
+                               t-0                       t-1
     2022  (2022-07-04, 2022-12-31]  (2022-01-05, 2022-07-04]
     2021  (2021-07-04, 2021-12-31]  (2021-01-05, 2021-07-04]
     2020  (2020-07-04, 2020-12-31]  (2020-01-06, 2020-07-04]

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -34,7 +34,10 @@ class TestAdventCalendar:
         cal = AdventCalendar(anchor_date=(12, 31), freq="180d")
         year = cal.map_year(2020)
         expected = np.array(
-            [interval("2020-07-04", "2020-12-31"), interval("2020-01-06", "2020-07-04")]
+            [
+                interval("2020-07-04", "2020-12-31"),
+                interval("2020-01-06", "2020-07-04"),
+            ]
         )
         assert np.array_equal(year, expected)
 

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -3,78 +3,108 @@
 import numpy as np
 import pandas as pd
 import pytest
-from s2s.time import TimeIndex
+from s2s.time import AdventCalendar
 
 
-class TestTimeIndex:
+def interval(start, end):
+    """Shorthand for more readable tests."""
+    return pd.Interval(pd.Timestamp(start), pd.Timestamp(end))
+
+
+class TestAdventCalendar:
     def test_init(self):
-        index = TimeIndex()
-        expected = pd.interval_range(
-            end=pd.Timestamp("2020-11-30"), periods=52, freq="7d"
-        )
-        # TODO make more useful tests
-        np.array_equal(index._index, expected)  # noqa
+        cal = AdventCalendar()
+        assert isinstance(cal, AdventCalendar)
+
+    def test_repr(self):
+        cal = AdventCalendar()
+        assert repr(cal) == "AdventCalendar(month=11, day=30, freq=7d, n=52)"
 
     def test_str(self):
-        index = TimeIndex()
-        assert str(index) == str(index._index)  # noqa
+        cal = AdventCalendar()
+        assert str(cal) == "52 periods of 7d leading up to 11/30."
 
     def test_discard(self):
-        index = TimeIndex()
+        cal = AdventCalendar()
 
         with pytest.raises(NotImplementedError):
-            index.discard(max_lag=5)
+            cal.discard(max_lag=5)
+
+    def test_map_year(self):
+        cal = AdventCalendar(anchor_date=(12, 31), freq="180d")
+        year = cal.map_year(2020)
+        expected = np.array(
+            [interval("2020-07-04", "2020-12-31"), interval("2020-01-06", "2020-07-04")]
+        )
+        assert np.array_equal(year.values, expected)
+
+    def test_map_years(self):
+        cal = AdventCalendar(anchor_date=(12, 31), freq="180d")
+        years = cal.map_years(2020, 2021)
+        expected = np.array(
+            [
+                [
+                    interval("2021-07-04", "2021-12-31"),
+                    interval("2021-01-05", "2021-07-04"),
+                ],
+                [
+                    interval("2020-07-04", "2020-12-31"),
+                    interval("2020-01-06", "2020-07-04"),  # notice the leap day
+                ],
+            ]
+        )
+        assert np.array_equal(years.values, expected)
 
     def test_mark_target_period(self):
-        index = TimeIndex()
+        cal = AdventCalendar()
 
         with pytest.raises(NotImplementedError):
-            index.mark_target_period(end='20200101', periods=5)
+            cal.mark_target_period(end="20200101", periods=5)
 
         with pytest.raises(NotImplementedError):
-            index.mark_target_period(start='20200101', periods=5)
+            cal.mark_target_period(start="20200101", periods=5)
 
         with pytest.raises(NotImplementedError):
-            index.mark_target_period(start='20190101', end='20200101')
+            cal.mark_target_period(start="20190101", end="20200101")
 
         with pytest.raises(ValueError):
-            index.mark_target_period(end='20200101')
+            cal.mark_target_period(end="20200101")
 
     def test_resample_with_dataframe(self):
-        index = TimeIndex()
+        cal = AdventCalendar()
         df = pd.DataFrame([1, 2, 3], index=pd.date_range("20200101", periods=3))
 
         with pytest.raises(NotImplementedError):
-            index.resample(df)
+            cal.resample(df)
 
     def test_resample_with_dataarray(self):
-        index = TimeIndex()
+        cal = AdventCalendar()
         df = pd.DataFrame([1, 2, 3], index=pd.date_range("20200101", periods=3))
         da = df.to_xarray()
 
         with pytest.raises(NotImplementedError):
-            index.resample(da)
+            cal.resample(da)
 
     def test_get_lagged_indices(self):
-        index = TimeIndex()
+        cal = AdventCalendar()
 
         with pytest.raises(NotImplementedError):
-            index.get_lagged_indices()
+            cal.get_lagged_indices()
 
     def test_get_train_indices(self):
-        index = TimeIndex()
+        cal = AdventCalendar()
 
         with pytest.raises(NotImplementedError):
-            index.get_train_indices("leave_n_out", {"n": 5})
+            cal.get_train_indices("leave_n_out", {"n": 5})
 
     def test_get_test_indices(self):
-        index = TimeIndex()
+        cal = AdventCalendar()
 
         with pytest.raises(NotImplementedError):
-            index.get_test_indices("leave_n_out", {"n": 5})
+            cal.get_test_indices("leave_n_out", {"n": 5})
 
     def get_train_test_indices(self):
-        index = TimeIndex()
+        cal = AdventCalendar()
 
         with pytest.raises(NotImplementedError):
-            index.get_train_test_indices("leave_n_out", {"n": 5})
+            cal.get_train_test_indices("leave_n_out", {"n": 5})

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -36,7 +36,7 @@ class TestAdventCalendar:
         expected = np.array(
             [interval("2020-07-04", "2020-12-31"), interval("2020-01-06", "2020-07-04")]
         )
-        assert np.array_equal(year.values, expected)
+        assert np.array_equal(year, expected)
 
     def test_map_years(self):
         cal = AdventCalendar(anchor_date=(12, 31), freq="180d")
@@ -53,7 +53,7 @@ class TestAdventCalendar:
                 ],
             ]
         )
-        assert np.array_equal(years.values, expected)
+        assert np.array_equal(years, expected)
 
     def test_mark_target_period(self):
         cal = AdventCalendar()


### PR DESCRIPTION
Far from ready, but good enough to build upon. 

closes #8 

How to use:

```py
import s2s.time

cal = s2s.time.AdventCalendar(anchor_date=(11, 30), freq='7d')
cal
>> "AdventCalendar(month=11, day=30, freq=7d, n=52)"

print(cal)
>> "52 periods of 7d leading up to 11/30."

# get time indexers
year = cal.map_year(2020)
years = cal.map_years(2020, 2022)
years_flat = cal.map_years(2020, 2022, flat=True)
```